### PR TITLE
Changes in swift syntax with respect to enums:

### DIFF
--- a/HTMLNode.swift
+++ b/HTMLNode.swift
@@ -107,7 +107,7 @@ class HTMLNode {
         self.doc  = doc
         self.node = node.memory
 
-        if let type = HTMLNodeType(rawValue: tagName) {
+        if let type = HTMLNodeType.fromRaw(tagName) {
             nodeType = type
         }
     }


### PR DESCRIPTION
Swift is a moving target. Creating an enum from its raw value seems to have changed. The below change makes it work again.

new:

if let type = HTMLNodeType.fromRaw(tagName) {

old:

if let type = HTMLNodeType(rawValue: tagName) {
