### PR TITLE
fixes missing method

### DIFF
--- a/HTMLNode.swift
+++ b/HTMLNode.swift
@@ -107,7 +107,7 @@ class HTMLNode {
         self.doc  = doc
         self.node = node.memory
 
-        if let type = HTMLNodeType.fromRaw(tagName) {
+        if let type = HTMLNodeType(rawValue: tagName) {
             nodeType = type
         }
     }


### PR DESCRIPTION
In Swift 1.1 the method fromRaw does not exist.
