### PR TITLE
XML Memory Leak Fix

### DIFF
--- a/Sources/libxmlHTMLDocument.swift
+++ b/Sources/libxmlHTMLDocument.swift
@@ -166,6 +166,10 @@ internal final class libxmlXMLDocument: XMLDocument {
         }
     }
     
+    deinit {
+        xmlFreeDoc(self.docPtr)
+    }
+    
     func xpath(xpath: String, namespaces: [String:String]?) -> XMLNodeSet {
         return rootNode?.xpath(xpath, namespaces: namespaces) ?? XMLNodeSet()
     }


### PR DESCRIPTION
Fixes a memory leak with 'libxmlXMLDocument' class by freeing the document on deinit.