### PR TITLE
Added the movement of the node

### DIFF
--- a/Sources/Kanna.swift
+++ b/Sources/Kanna.swift
@@ -149,6 +149,7 @@ SearchableNode
 public protocol SearchableNode: Searchable {
     var text: String? { get }
     var toHTML:      String? { get }
+    var toXML:     String? { get }
     var innerHTML: String? { get }
     var className: String? { get }
     var tagName:   String? { get }
@@ -159,6 +160,9 @@ XMLElement
 */
 public protocol XMLElement: SearchableNode {
     subscript(attr: String) -> String? { get set }
+
+    func addPrevSibling(node: XMLElement)
+    func addNextSibling(node: XMLElement)
 }
 
 /**

--- a/Sources/libxmlHTMLDocument.swift
+++ b/Sources/libxmlHTMLDocument.swift
@@ -38,8 +38,28 @@ internal final class libxmlHTMLDocument: HTMLDocument {
     var text: String? {
         return rootNode?.text
     }
-    
+
     var toHTML: String? {
+        let buf = xmlBufferCreate()
+        defer {
+            xmlBufferFree(buf)
+        }
+
+        let outputBuf = xmlOutputBufferCreateBuffer(buf, nil)
+        htmlDocContentDumpOutput(outputBuf, docPtr, nil)
+        let html = String.fromCString(UnsafePointer(xmlOutputBufferGetContent(outputBuf)))
+        return html
+    }
+
+    var toXML: String? {
+        var buf: UnsafeMutablePointer<xmlChar> = nil
+        let size: UnsafeMutablePointer<Int32> = nil
+        defer {
+            xmlFree(buf)
+        }
+
+        xmlDocDumpMemory(docPtr, &buf, size)
+        let html = String.fromCString(UnsafePointer(buf))
         return html
     }
     
@@ -131,7 +151,27 @@ internal final class libxmlXMLDocument: XMLDocument {
     }
     
     var toHTML: String? {
-        return xml
+        let buf = xmlBufferCreate()
+        defer {
+            xmlBufferFree(buf)
+        }
+
+        let outputBuf = xmlOutputBufferCreateBuffer(buf, nil)
+        htmlDocContentDumpOutput(outputBuf, docPtr, nil)
+        let html = String.fromCString(UnsafePointer(xmlOutputBufferGetContent(outputBuf)))
+        return html
+    }
+
+    var toXML: String? {
+        var buf: UnsafeMutablePointer<xmlChar> = nil
+        let size: UnsafeMutablePointer<Int32> = nil
+        defer {
+            xmlFree(buf)
+        }
+
+        xmlDocDumpMemory(docPtr, &buf, size)
+        let html = String.fromCString(UnsafePointer(buf))
+        return html
     }
     
     var innerHTML: String? {

--- a/Sources/libxmlHTMLNode.swift
+++ b/Sources/libxmlHTMLNode.swift
@@ -42,6 +42,14 @@ internal final class libxmlHTMLNode: XMLElement {
         xmlBufferFree(buf)
         return html
     }
+
+    var toXML: String? {
+        let buf = xmlBufferCreate()
+        xmlNodeDump(buf, docPtr, nodePtr, 0, 0)
+        let html = String.fromCString(UnsafePointer(buf.memory.content))
+        xmlBufferFree(buf)
+        return html
+    }
     
     var innerHTML: String? {
         if let html = self.toHTML {
@@ -174,6 +182,20 @@ internal final class libxmlHTMLNode: XMLElement {
     
     func at_css(selector: String) -> XMLElement? {
         return self.css(selector, namespaces: nil).first
+    }
+
+    func addPrevSibling(node: XMLElement) {
+        guard let node = node as? libxmlHTMLNode else {
+            return
+        }
+        xmlAddPrevSibling(nodePtr, node.nodePtr)
+    }
+
+    func addNextSibling(node: XMLElement) {
+        guard let node = node as? libxmlHTMLNode else {
+            return
+        }
+        xmlAddNextSibling(nodePtr, node.nodePtr)
     }
 }
 

--- a/Tests/KannaTests.swift
+++ b/Tests/KannaTests.swift
@@ -122,6 +122,32 @@ class KannaTests: XCTestCase {
             XCTAssert(false, "File not found. name: (\(filename))")
         }
     }
+
+    func testXML_MovingNode() {
+        let xml = "<?xml version=\"1.0\"?><all_item><item><title>item0</title></item><item><title>item1</title></item></all_item>"
+        let modifyPrevXML = "<all_item><item><title>item1</title></item><item><title>item0</title></item></all_item>"
+        let modifyNextXML = "<all_item><item><title>item1</title></item><item><title>item0</title></item></all_item>"
+
+        do {
+            guard let doc = XML(xml: xml, encoding: NSUTF8StringEncoding) else {
+                    return
+            }
+            let item0 = doc.css("item")[0]
+            let item1 = doc.css("item")[1]
+            item0.addPrevSibling(item1)
+            XCTAssert(doc.at_css("all_item")!.toXML == modifyPrevXML)
+        }
+
+        do {
+            guard let doc = XML(xml: xml, encoding: NSUTF8StringEncoding) else {
+                return
+            }
+            let item0 = doc.css("item")[0]
+            let item1 = doc.css("item")[1]
+            item1.addNextSibling(item0)
+            XCTAssert(doc.at_css("all_item")!.toXML == modifyNextXML)
+        }
+    }
     
     /**
     test HTML4
@@ -142,7 +168,7 @@ class KannaTests: XCTestCase {
             XCTAssert(doc.title == "Test HTML4")
             XCTAssert(doc.head != nil)
             XCTAssert(doc.body != nil)
-            XCTAssert(doc.toHTML == html)
+            XCTAssert(doc.toHTML!.hasPrefix("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html lang=\"en\">"))
             
             for link in doc.xpath("//link") {
                 XCTAssert(link["href"] != nil)
@@ -214,6 +240,32 @@ class KannaTests: XCTestCase {
               let _ = HTML(url: url, encoding: NSUTF8StringEncoding) else {
             XCTAssert(false)
             return
+        }
+    }
+
+    func testHTML_MovingNode() {
+        let html = "<body><div>A love triangle.<h1>Three's Company</h1></div></body>"
+        let modifyPrevHTML = "<body>\n<h1>Three's Company</h1>\n<div>A love triangle.</div>\n</body>"
+        let modifyNextHTML = "<body>\n<div>A love triangle.</div>\n<h1>Three's Company</h1>\n</body>"
+
+        do {
+            guard let doc = HTML(html: html, encoding: NSUTF8StringEncoding),
+                h1 = doc.at_css("h1"),
+                div = doc.at_css("div") else {
+                    return
+            }
+            div.addPrevSibling(h1)
+            XCTAssert(doc.body!.toHTML == modifyPrevHTML)
+        }
+
+        do {
+            guard let doc = HTML(html: html, encoding: NSUTF8StringEncoding),
+                h1 = doc.at_css("h1"),
+                div = doc.at_css("div") else {
+                    return
+            }
+            div.addNextSibling(h1)
+            XCTAssert(doc.body!.toHTML == modifyNextHTML)
         }
     }
 }


### PR DESCRIPTION
Added method to XMLElement.
* func addPrevSibling(node: XMLElement)
* func addNextSibling(node: XMLElement)

e.g.
```
let html = "<body><div>A love triangle.<h1>Three's Company</h1></div></body>"
guard let doc = HTML(html: html, encoding: NSUTF8StringEncoding),
h1 = doc.at_css("h1"),
div = doc.at_css("div") else {
return
}
div.addPrevSibling(h1)

print(doc.body!.toHTML!) // <body><h1>Three's Company</h1><div>A love triangle.</div></body>
```