### PR TITLE
added property to allow removal of child nodes

### DIFF
--- a/Sources/Kanna.swift
+++ b/Sources/Kanna.swift
@@ -165,6 +165,7 @@ public protocol XMLElement: SearchableNode {
 
     func addPrevSibling(node: XMLElement)
     func addNextSibling(node: XMLElement)
+    func removeChild(node: XMLElement)
 }
 
 /**

--- a/Sources/libxmlHTMLNode.swift
+++ b/Sources/libxmlHTMLNode.swift
@@ -227,6 +227,15 @@ internal final class libxmlHTMLNode: XMLElement {
         xmlUnlinkNode(node.nodePtr)
         xmlAddChild(nodePtr, node.nodePtr)
     }
+    
+    func removeChild(node: XMLElement) {
+        
+        guard let node = node as? libxmlHTMLNode else {
+            return
+        }
+        xmlUnlinkNode(node.nodePtr)
+        xmlFree(node.nodePtr)
+    }
 }
 
 private func libxmlGetNodeContent(nodePtr: xmlNodePtr) -> String? {


### PR DESCRIPTION
#30 

Hey @tid-kijyun, submitting a PR to allow for the removal of nodes. Let me know your thoughts.

Also I noticed that when you loop through via CSS selector, you can't set the contents of the node without copying it into another variable, since `doc.css(:)` will return you an immutable `XMLNodeSet` as an enum property of `XPathObject`. This actually prevents you from editing the nodes in the `HTMLDocument`. Is this the intended behavior? 