### PR TITLE
Fixed an issue where the encoding is not correctly set somehow.

### DIFF
--- a/Sources/libxmlHTMLDocument.swift
+++ b/Sources/libxmlHTMLDocument.swift
@@ -84,11 +84,11 @@ internal final class libxmlHTMLDocument: HTMLDocument {
             return nil
         }
         let cfenc : CFStringEncoding = CFStringConvertNSStringEncodingToEncoding(encoding.rawValue)
-        let cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc)
+        let cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc) as? String
         
         if let cur = html.cString(using: encoding) {
             let url : String = ""
-            docPtr = htmlReadDoc(UnsafeRawPointer(cur).assumingMemoryBound(to: xmlChar.self), url, (cfencstr as? String) ?? "", CInt(option))
+            docPtr = htmlReadDoc(UnsafeRawPointer(cur).assumingMemoryBound(to: xmlChar.self), url, cfencstr ?? "", CInt(option))
             rootNode  = libxmlHTMLNode(docPtr: docPtr!)
         } else {
             return nil


### PR DESCRIPTION
Hmm, I was using utf-8 encoding to parse the html but that parameter was not correctly pass through to libxml. It seems it was due to CFString to String conversion. Check the commit for details.

I'll add some test cases later tonight.