### PR TITLE
Add name to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 import PackageDescription
 
 let package = Package(
+    name: "Kanna",
     dependencies: [
 		.Package(url: "../Kanna", majorVersion: 1)
     ]


### PR DESCRIPTION
otherwise `swift build` fails with `error: missing argument for parameter 'name' in call` 🙂