### PR TITLE
Swift 4.0 includes NSTextCheckingResult on Linux

### DIFF
--- a/Sources/Kanna/CSS.swift
+++ b/Sources/Kanna/CSS.swift
@@ -30,13 +30,8 @@ import SwiftClibxml2
 import libxml2
 #endif
 
-#if os(Linux)
-typealias AKTextCheckingResult = TextCheckingResult
-typealias AKRegularExpression  = NSRegularExpression
-#else
 typealias AKRegularExpression  = NSRegularExpression
 typealias AKTextCheckingResult = NSTextCheckingResult
-#endif
 
 public enum CSSError: Error {
     case UnsupportSyntax(String)


### PR DESCRIPTION
### Description:
With the latest version of Swift on Ubuntu 16.04, compiling Kanna on `feature/v4.0.0` fails.

```
Swift version 4.0 (swift-4.0-RELEASE)
Target: x86_64-unknown-linux-gnu
```

Error: 

```
/var/www/awesome-project/.build/checkouts/Kanna.git-2681806990078238574/Sources/Kanna/CSS.swift:34:34: error: use of undeclared type 'TextCheckingResult'
typealias AKTextCheckingResult = TextCheckingResult
                                 ^~~~~~~~~~~~~~~~~~
```

Changing `TextCheckingResult` to `NSTextCheckingResult` solves the issue.

### Installation method:
- [ ] Carthage
- [ ] CocoaPods(1.1.0 or later)
- [X] Swift Package Manager
- [ ] Manually
- [ ] other: ()

### Library version:
- [ ] v2.1.1
- [X] other: feature/4.0.0

### Xcode version:
- [ ] 8.1 (Swift 3) 
- [ ] 8.1 (Swift 2.3)
- [ ] 7.3.1
- [X] other: Ubuntu 16.04
