### PR TITLE
rangeAt error and characters warning fixed.

### DIFF
--- a/Sources/Kanna/CSS.swift
+++ b/Sources/Kanna/CSS.swift
@@ -150,7 +150,7 @@ private let matchSubBlank     = firstMatch("^\\s*$")
 
 private func substringWithRangeAtIndex(_ result: AKTextCheckingResult, str: String, at: Int) -> String {
     if result.numberOfRanges > at {
-        let range = result.range(at: at)
+        let range = result.rangeAt(at)
         if range.length > 0 {
             let startIndex = str.index(str.startIndex, offsetBy: range.location)
             let endIndex = str.index(startIndex, offsetBy: range.length)
@@ -308,13 +308,13 @@ private func getAttrNot(_ str: inout String, skip: Bool = true) -> String? {
     if let result = matchAttrN(str) {
         var one = substringWithRangeAtIndex(result, str: str, at: 1)
         if skip {
-            str = String(str[str.characters.index(str.startIndex, offsetBy: result.range.length)..<str.endIndex])
+            str = String(str[str.index(str.startIndex, offsetBy: result.range.length)..<str.endIndex])
         }
         
         if let attr = getAttribute(&one, skip: false) {
             return attr
         } else if let sub = matchElement(one) {
-            let range = sub.range(at: 1)
+            let range = sub.rangeAt(1)
             let startIndex = one.index(one.startIndex, offsetBy: range.location)
             let endIndex   = one.index(startIndex, offsetBy: range.length)
 
@@ -331,7 +331,7 @@ private func genCombinator(_ str: inout String, skip: Bool = true) -> String? {
     if let result = matchCombinator(str) {
         let one = substringWithRangeAtIndex(result, str: str, at: 1)
         if skip {
-            str = String(str[str.characters.index(str.startIndex, offsetBy: result.range.length)..<str.endIndex])
+            str = String(str[str.index(str.startIndex, offsetBy: result.range.length)..<str.endIndex])
         }
         
         switch one {


### PR DESCRIPTION
```
'range(at:)' has been renamed to 'rangeAt(_:)'
'characters' is deprecated: Please use String or Substring directly
```
I was getting related bugs and warnings. It works fine when I change it.