### PR TITLE
Swift 5.1

### DIFF
--- a/Sources/Kanna/CSS.swift
+++ b/Sources/Kanna/CSS.swift
@@ -51,8 +51,8 @@ public enum CSS {
     @return XPath
     */
     public static func toXPath(_ css: String) throws -> String {
-        let selectorGroups = css.components(separatedBy: ",")
-        return try selectorGroups
+        try css
+            .components(separatedBy: ",")
             .map { try toXPath(selector: $0) }
             .joined(separator: " | ")
     }
@@ -104,7 +104,7 @@ public enum CSS {
 }
 
 private func firstMatch(_ pattern: String) -> (String) -> AKTextCheckingResult? {
-    return { str in
+    { str in
         let length = str.utf16.count
         do {
             let regex = try AKRegularExpression(pattern: pattern, options: .caseInsensitive)
@@ -134,11 +134,11 @@ private func nth(prefix: String, a: Int, b: Int) -> String {
 
 // a(n) + b | a(n) - b
 private func nth_child(a: Int, b: Int) -> String {
-    return nth(prefix: "preceding", a: a, b: b)
+    nth(prefix: "preceding", a: a, b: b)
 }
 
 private func nth_last_child(a: Int, b: Int) -> String {
-    return nth(prefix: "following", a: a, b: b)
+    nth(prefix: "following", a: a, b: b)
 }
 
 private let escapePattern = "(?:\\\\([!\"#\\$%&\'\\(\\)\\*\\+,\\./:;<=>\\?@\\[\\\\\\]\\^`\\{\\|\\}~]))"
@@ -172,7 +172,7 @@ private func substringWithRangeAtIndex(_ result: AKTextCheckingResult, str: Stri
 }
 
 private func escapeCSS(_ text: String) -> String {
-    return text.replacingOccurrences(of: escapePattern, with: "$1", options: .regularExpression, range: nil)
+    text.replacingOccurrences(of: escapePattern, with: "$1", options: .regularExpression, range: nil)
 }
 
 private func getElement(_ str: inout String, skip: Bool = true) -> String {

--- a/Sources/Kanna/Deprecated.swift
+++ b/Sources/Kanna/Deprecated.swift
@@ -13,17 +13,17 @@ import Foundation
 //-------------------------------------------------------------
 @available(*, unavailable, message: "Use XML(xml: String, url: String?, encoding: String.Encoding, option: ParseOption). The type of the second argument has been changed to String.Encoding from UInt.")
 public func XML(xml: String, url: String? = nil, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) -> XMLDocument? {
-    return nil
+    nil
 }
 
 @available(*, unavailable, message: "Use XML(xml: Data, url: String?, encoding: String.Encoding, option: ParseOption). The type of the first argument has been changed to Data and the type of the second argument has been changed to String.Encoding from UInt.")
 public func XML(xml: NSData, url: String? = nil, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) ->  XMLDocument? {
-    return nil
+    nil
 }
 
 @available(*, unavailable, message: "Use XML(url: URL, encoding: String.Encoding, option: ParseOption). The type of the second argument has been changed to String.Encoding from UInt.")
 public func XML(url: URL, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) -> XMLDocument? {
-    return nil
+    nil
 }
 
 //-------------------------------------------------------------
@@ -31,15 +31,15 @@ public func XML(url: URL, encoding: UInt, option: ParseOption = kDefaultXmlParse
 //-------------------------------------------------------------
 @available(*, unavailable, message: "Use HTML(html: String, url: String?, encoding: String.Encoding, option: ParseOption). The type of the second argument has been changed to String.Encoding from UInt.")
 public func HTML(html: String, url: String? = nil, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) -> XMLDocument? {
-    return nil
+    nil
 }
 
 @available(*, unavailable, message: "Use HTML(html: Data, url: String?, encoding: String.Encoding, option: ParseOption). The type of the first argument has been changed to Data and the type of the second argument has been changed to String.Encoding from UInt.")
 public func HTML(html: NSData, url: String? = nil, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) ->  XMLDocument? {
-    return nil
+    nil
 }
 
 @available(*, unavailable, message: "Use HTML(url: URL, encoding: String.Encoding, option: ParseOption). The type of the second argument has been changed to String.Encoding from UInt.")
 public func HTML(url: URL, encoding: UInt, option: ParseOption = kDefaultXmlParseOption) -> XMLDocument? {
-    return nil
+    nil
 }

--- a/Sources/Kanna/Kanna.swift
+++ b/Sources/Kanna/Kanna.swift
@@ -182,7 +182,7 @@ public protocol HTMLDocument: XMLDocument {
 XMLNodeSet
 */
 public final class XMLNodeSet {
-    fileprivate var nodes: [XMLElement] = []
+    private var nodes: [XMLElement] = []
     
     public var toHTML: String? {
         let html = nodes.reduce("") {
@@ -215,31 +215,23 @@ public final class XMLNodeSet {
     }
     
     public subscript(index: Int) -> XMLElement {
-        return nodes[index]
+        nodes[index]
     }
     
-    public var count: Int {
-        return nodes.count
-    }
+    public var count: Int { nodes.count }
     
-    internal init() {
-    }
+    init() {}
     
-    internal init(nodes: [XMLElement]) {
+    init(nodes: [XMLElement]) {
         self.nodes = nodes
     }
     
     public func at(_ index: Int) -> XMLElement? {
-        return count > index ? nodes[index] : nil
+        count > index ? nodes[index] : nil
     }
-    
-    public var first: XMLElement? {
-        return at(0)
-    }
-    
-    public var last: XMLElement? {
-        return at(count-1)
-    }
+
+    public var first: XMLElement? { at(0) }
+    public var last: XMLElement? { at(count - 1) }
 }
 
 extension XMLNodeSet: Sequence {
@@ -278,7 +270,7 @@ public enum XPathObject {
 }
 
 extension XPathObject {
-    internal init(document: XMLDocument?, docPtr: xmlDocPtr, object: xmlXPathObject) {
+    init(document: XMLDocument?, docPtr: xmlDocPtr, object: xmlXPathObject) {
         switch object.type {
         case XPATH_NODESET:
             let nodeSet = object.nodesetval
@@ -315,18 +307,15 @@ extension XPathObject {
     }
 
     public subscript(index: Int) -> XMLElement {
-        return nodeSet![index]
+        nodeSet![index]
     }
 
     public var first: XMLElement? {
-        return nodeSet?.first
+        nodeSet?.first
     }
 
     public var count: Int {
-        guard let nodeset = nodeSet else {
-            return 0
-        }
-        return nodeset.count
+        nodeSet?.count ?? 0
     }
 
     var nodeSet: XMLNodeSet? {
@@ -358,19 +347,19 @@ extension XPathObject {
     }
     
     var nodeSetValue: XMLNodeSet {
-        return nodeSet ?? XMLNodeSet()
+        nodeSet ?? XMLNodeSet()
     }
     
     var boolValue: Swift.Bool {
-        return bool ?? false
+        bool ?? false
     }
     
     var numberValue: Double {
-        return number ?? 0.0
+        number ?? 0
     }
     
     var stringValue: Swift.String {
-        return string ?? ""
+        string ?? ""
     }
 }
 

--- a/Sources/Kanna/libxmlHTMLDocument.swift
+++ b/Sources/Kanna/libxmlHTMLDocument.swift
@@ -128,7 +128,7 @@ extension String.Encoding {
             return nil
         }
         #else
-        let cfenc = CFStringConvertNSStringEncodingToEncoding(self.rawValue)
+        let cfenc = CFStringConvertNSStringEncodingToEncoding(rawValue)
         guard let cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc) else {
             return nil
         }
@@ -140,16 +140,14 @@ extension String.Encoding {
 /*
 libxmlHTMLDocument
 */
-internal final class libxmlHTMLDocument: HTMLDocument {
-    fileprivate var docPtr:   htmlDocPtr? = nil
-    fileprivate var rootNode: XMLElement?
-    fileprivate var html: String
-    fileprivate var url:  String?
-    fileprivate var encoding: String.Encoding
+final class libxmlHTMLDocument: HTMLDocument {
+    private var docPtr:   htmlDocPtr? = nil
+    private var rootNode: XMLElement?
+    private var html: String
+    private var url:  String?
+    private var encoding: String.Encoding
     
-    var text: String? {
-        return rootNode?.text
-    }
+    var text: String? { rootNode?.text }
 
     var toHTML: String? {
         let buf = xmlBufferCreate()
@@ -176,37 +174,21 @@ internal final class libxmlHTMLDocument: HTMLDocument {
         return html
     }
     
-    var innerHTML: String? {
-        return rootNode?.innerHTML
-    }
+    var innerHTML: String? { rootNode?.innerHTML }
     
-    var className: String? {
-        return nil
-    }
+    var className: String? { nil }
     
-    var tagName:   String? {
-        get {
-            return nil
-        }
-
-        set {
-
-        }
+    var tagName: String? {
+        get { nil }
+        set {}
     }
 
     var content: String? {
-        get {
-            return text
-        }
-
-        set {
-            rootNode?.content = newValue
-        }
+        get { text }
+        set { rootNode?.content = newValue }
     }
 
-    var namespaces: [Namespace] {
-        return getNamespaces(docPtr: docPtr)
-    }
+    var namespaces: [Namespace] { getNamespaces(docPtr: docPtr) }
     
     init(html: String, url: String?, encoding: String.Encoding, option: UInt) throws {
         self.html = html
@@ -233,59 +215,57 @@ internal final class libxmlHTMLDocument: HTMLDocument {
     }
     
     deinit {
-        xmlFreeDoc(self.docPtr)
+        xmlFreeDoc(docPtr)
     }
 
-    var title: String? { return at_xpath("//title")?.text }
-    var head: XMLElement? { return at_xpath("//head") }
-    var body: XMLElement? { return at_xpath("//body") }
+    var title: String? { at_xpath("//title")?.text }
+    var head: XMLElement? { at_xpath("//head") }
+    var body: XMLElement? { at_xpath("//body") }
     
     func xpath(_ xpath: String, namespaces: [String:String]?) -> XPathObject {
-        return rootNode?.xpath(xpath, namespaces: namespaces) ?? XPathObject.none
+        rootNode?.xpath(xpath, namespaces: namespaces) ?? .none
     }
     
     func xpath(_ xpath: String) -> XPathObject {
-        return self.xpath(xpath, namespaces: nil)
+        self.xpath(xpath, namespaces: nil)
     }
     
     func at_xpath(_ xpath: String, namespaces: [String:String]?) -> XMLElement? {
-        return rootNode?.at_xpath(xpath, namespaces: namespaces)
+        rootNode?.at_xpath(xpath, namespaces: namespaces)
     }
     
     func at_xpath(_ xpath: String) -> XMLElement? {
-        return self.at_xpath(xpath, namespaces: nil)
+        self.at_xpath(xpath, namespaces: nil)
     }
     
     func css(_ selector: String, namespaces: [String:String]?) -> XPathObject {
-        return rootNode?.css(selector, namespaces: namespaces) ?? XPathObject.none
+        rootNode?.css(selector, namespaces: namespaces) ?? .none
     }
     
     func css(_ selector: String) -> XPathObject {
-        return self.css(selector, namespaces: nil)
+        self.css(selector, namespaces: nil)
     }
     
     func at_css(_ selector: String, namespaces: [String:String]?) -> XMLElement? {
-        return rootNode?.at_css(selector, namespaces: namespaces)
+        rootNode?.at_css(selector, namespaces: namespaces)
     }
     
     func at_css(_ selector: String) -> XMLElement? {
-        return self.at_css(selector, namespaces: nil)
+        self.at_css(selector, namespaces: nil)
     }
 }
 
 /*
 libxmlXMLDocument
 */
-internal final class libxmlXMLDocument: XMLDocument {
-    fileprivate var docPtr:   xmlDocPtr? = nil
-    fileprivate var rootNode: XMLElement?
-    fileprivate var xml: String
-    fileprivate var url: String?
-    fileprivate var encoding: String.Encoding
+final class libxmlXMLDocument: XMLDocument {
+    private var docPtr:   xmlDocPtr? = nil
+    private var rootNode: XMLElement?
+    private var xml: String
+    private var url: String?
+    private var encoding: String.Encoding
     
-    var text: String? {
-        return rootNode?.text
-    }
+    var text: String? { rootNode?.text }
     
     var toHTML: String? {
         let buf = xmlBufferCreate()
@@ -312,41 +292,25 @@ internal final class libxmlXMLDocument: XMLDocument {
         return html
     }
     
-    var innerHTML: String? {
-        return rootNode?.innerHTML
-    }
+    var innerHTML: String? { rootNode?.innerHTML }
     
-    var className: String? {
-        return nil
-    }
+    var className: String? { nil }
     
-    var tagName:   String? {
-        get {
-            return nil
-        }
-
-        set {
-            
-        }
+    var tagName: String? {
+        get { nil }
+        set {}
     }
 
     var content: String? {
-        get {
-            return text
-        }
-
-        set {
-            rootNode?.content = newValue
-        }
+        get { text }
+        set { rootNode?.content = newValue }
     }
 
-    var namespaces: [Namespace] {
-        return getNamespaces(docPtr: docPtr)
-    }
+    var namespaces: [Namespace] { getNamespaces(docPtr: docPtr) }
     
     init(xml: String, url: String?, encoding: String.Encoding, option: UInt) throws {
-        self.xml  = xml
-        self.url  = url
+        self.xml = xml
+        self.url = url
         self.encoding = encoding
         
         if xml.isEmpty {
@@ -364,39 +328,39 @@ internal final class libxmlXMLDocument: XMLDocument {
     }
 
     deinit {
-        xmlFreeDoc(self.docPtr)
+        xmlFreeDoc(docPtr)
     }
     
     func xpath(_ xpath: String, namespaces: [String:String]?) -> XPathObject {
-        return rootNode?.xpath(xpath, namespaces: namespaces) ?? XPathObject.none
+        rootNode?.xpath(xpath, namespaces: namespaces) ?? .none
     }
     
     func xpath(_ xpath: String) -> XPathObject {
-        return self.xpath(xpath, namespaces: nil)
+        self.xpath(xpath, namespaces: nil)
     }
     
     func at_xpath(_ xpath: String, namespaces: [String:String]?) -> XMLElement? {
-        return rootNode?.at_xpath(xpath, namespaces: namespaces)
+        rootNode?.at_xpath(xpath, namespaces: namespaces)
     }
     
     func at_xpath(_ xpath: String) -> XMLElement? {
-        return self.at_xpath(xpath, namespaces: nil)
+        self.at_xpath(xpath, namespaces: nil)
     }
     
     func css(_ selector: String, namespaces: [String:String]?) -> XPathObject {
-        return rootNode?.css(selector, namespaces: namespaces) ?? XPathObject.none
+        rootNode?.css(selector, namespaces: namespaces) ?? .none
     }
     
     func css(_ selector: String) -> XPathObject {
-        return self.css(selector, namespaces: nil)
+        self.css(selector, namespaces: nil)
     }
     
     func at_css(_ selector: String, namespaces: [String:String]?) -> XMLElement? {
-        return rootNode?.at_css(selector, namespaces: namespaces)
+        rootNode?.at_css(selector, namespaces: namespaces)
     }
     
     func at_css(_ selector: String) -> XMLElement? {
-        return self.at_css(selector, namespaces: nil)
+        self.at_css(selector, namespaces: nil)
     }
 }
 

--- a/Sources/Kanna/libxmlHTMLNode.swift
+++ b/Sources/Kanna/libxmlHTMLNode.swift
@@ -29,12 +29,10 @@ import libxmlKanna
 /**
 libxmlHTMLNode
 */
-internal final class libxmlHTMLNode: XMLElement {
+final class libxmlHTMLNode: XMLElement {
     var text: String? {
-        if nodePtr != nil {
-            return libxmlGetNodeContent(nodePtr!)
-        }
-        return nil
+        guard let nodePtr = nodePtr else { return nil }
+        return libxmlGetNodeContent(nodePtr)
     }
     
     var toHTML: String? {
@@ -54,26 +52,23 @@ internal final class libxmlHTMLNode: XMLElement {
     }
     
     var innerHTML: String? {
-        if let html = self.toHTML {
-            let inner = html.replacingOccurrences(of: "</[^>]*>$", with: "", options: .regularExpression, range: nil)
-                            .replacingOccurrences(of: "^<[^>]*>", with: "", options: .regularExpression, range: nil)
-            return inner
-        }
-        return nil
+        guard let html = toHTML else { return nil }
+        return html
+            .replacingOccurrences(of: "</[^>]*>$", with: "", options: .regularExpression, range: nil)
+            .replacingOccurrences(of: "^<[^>]*>", with: "", options: .regularExpression, range: nil)
     }
     
     var className: String? {
-        return self["class"]
+        self["class"]
     }
-    
-    var tagName:   String? {
+
+    var tagName: String? {
         get {
             guard let name = nodePtr?.pointee.name else {
                 return nil
             }
             return String(cString: name)
         }
-
         set {
             if let newValue = newValue {
                 xmlNodeSetName(nodePtr, newValue)
@@ -82,10 +77,7 @@ internal final class libxmlHTMLNode: XMLElement {
     }
 
     var content: String? {
-        get {
-            return text
-        }
-
+        get { text }
         set {
             if let newValue = newValue {
                 let v = escape(newValue)
@@ -96,9 +88,8 @@ internal final class libxmlHTMLNode: XMLElement {
 
     var parent: XMLElement? {
         get {
-            return libxmlHTMLNode(document: doc, docPtr: docPtr!, node: (nodePtr?.pointee.parent)!)
+            libxmlHTMLNode(document: doc, docPtr: docPtr!, node: (nodePtr?.pointee.parent)!)
         }
-
         set {
             if let node = newValue as? libxmlHTMLNode {
                 node.addChild(self)
@@ -107,26 +98,23 @@ internal final class libxmlHTMLNode: XMLElement {
     }
 
     var nextSibling: XMLElement? {
-        let val = xmlNextElementSibling(self.nodePtr)
-        return self.node(from: val)
+        node(from: xmlNextElementSibling(nodePtr))
     }
 
     var previousSibling: XMLElement? {
-        let val = xmlPreviousElementSibling(self.nodePtr)
-        return self.node(from: val)
+        node(from: xmlPreviousElementSibling(nodePtr))
     }
 
-    fileprivate weak var weakDocument: XMLDocument?
-    fileprivate var document: XMLDocument?
-    fileprivate var docPtr:  htmlDocPtr? = nil
-    fileprivate var nodePtr: xmlNodePtr? = nil
-    fileprivate var isRoot:  Bool       = false
-    fileprivate var doc: XMLDocument? {
-        return weakDocument ?? document
+    private weak var weakDocument: XMLDocument?
+    private var document: XMLDocument?
+    private var docPtr: htmlDocPtr? = nil
+    private var nodePtr: xmlNodePtr? = nil
+    private var isRoot = false
+    private var doc: XMLDocument? {
+        weakDocument ?? document
     }
     
-    subscript(attributeName: String) -> String?
-    {
+    subscript(attributeName: String) -> String? {
         get {
             var attr = nodePtr?.pointee.properties
             while attr != nil {
@@ -144,7 +132,6 @@ internal final class libxmlHTMLNode: XMLElement {
             }
             return nil
         }
-        
         set(newValue) {
             if let newValue = newValue {
                 xmlSetProp(nodePtr, attributeName, newValue)
@@ -171,7 +158,7 @@ internal final class libxmlHTMLNode: XMLElement {
     func xpath(_ xpath: String, namespaces: [String:String]?) -> XPathObject {
         let ctxt = xmlXPathNewContext(docPtr)
         if ctxt == nil {
-            return XPathObject.none
+            return .none
         }
         ctxt?.pointee.node = nodePtr
         
@@ -187,22 +174,22 @@ internal final class libxmlHTMLNode: XMLElement {
         }
         xmlXPathFreeContext(ctxt)
         if result == nil {
-            return XPathObject.none
+            return .none
         }
 
         return XPathObject(document: doc, docPtr: docPtr!, object: result!.pointee)
     }
     
     func xpath(_ xpath: String) -> XPathObject {
-        return self.xpath(xpath, namespaces: nil)
+        self.xpath(xpath, namespaces: nil)
     }
     
     func at_xpath(_ xpath: String, namespaces: [String:String]?) -> XMLElement? {
-        return self.xpath(xpath, namespaces: namespaces).nodeSetValue.first
+        self.xpath(xpath, namespaces: namespaces).nodeSetValue.first
     }
     
     func at_xpath(_ xpath: String) -> XMLElement? {
-        return self.at_xpath(xpath, namespaces: nil)
+        self.at_xpath(xpath, namespaces: nil)
     }
     
     func css(_ selector: String, namespaces: [String:String]?) -> XPathObject {
@@ -213,19 +200,19 @@ internal final class libxmlHTMLNode: XMLElement {
                 return self.xpath("." + xpath, namespaces: namespaces)
             }
         }
-        return XPathObject.none
+        return .none
     }
     
     func css(_ selector: String) -> XPathObject {
-        return self.css(selector, namespaces: nil)
+        self.css(selector, namespaces: nil)
     }
     
     func at_css(_ selector: String, namespaces: [String:String]?) -> XMLElement? {
-        return self.css(selector, namespaces: namespaces).nodeSetValue.first
+        self.css(selector, namespaces: namespaces).nodeSetValue.first
     }
     
     func at_css(_ selector: String) -> XMLElement? {
-        return self.css(selector, namespaces: nil).nodeSetValue.first
+        self.css(selector, namespaces: nil).nodeSetValue.first
     }
 
     func addPrevSibling(_ node: XMLElement) {
@@ -260,12 +247,11 @@ internal final class libxmlHTMLNode: XMLElement {
     }
 
     private func node(from ptr: xmlNodePtr?) -> XMLElement? {
-        guard let doc = self.doc, let docPtr = self.docPtr, let nodePtr = ptr else {
+        guard let doc = doc, let docPtr = docPtr, let nodePtr = ptr else {
             return nil
         }
 
-        let element = libxmlHTMLNode(document: doc, docPtr: docPtr, node: nodePtr)
-        return element
+        return libxmlHTMLNode(document: doc, docPtr: docPtr, node: nodePtr)
     }
 }
 

--- a/Sources/Kanna/libxmlParserOption.swift
+++ b/Sources/Kanna/libxmlParserOption.swift
@@ -33,12 +33,12 @@ public struct Libxml2HTMLParserOptions : OptionSet {
     public typealias RawValue = UInt
     private var value: UInt = 0
     init(_ value: UInt) { self.value = value }
-    private init(_ opt: htmlParserOption) { self.value = UInt(opt.rawValue) }
+    private init(_ opt: htmlParserOption) { value = UInt(opt.rawValue) }
     public init(rawValue value: UInt) { self.value = value }
-    public init(nilLiteral: ()) { self.value = 0 }
-    public static var allZeros: Libxml2HTMLParserOptions { return .init(0) }
-    static func fromMask(raw: UInt) -> Libxml2HTMLParserOptions { return .init(raw) }
-    public var rawValue: UInt { return self.value }
+    public init(nilLiteral: ()) { value = 0 }
+    public static var allZeros: Libxml2HTMLParserOptions { .init(0) }
+    static func fromMask(raw: UInt) -> Libxml2HTMLParserOptions { .init(raw) }
+    public var rawValue: UInt { value }
     
     public static let STRICT     = Libxml2HTMLParserOptions(0)
     public static let RECOVER    = Libxml2HTMLParserOptions(HTML_PARSE_RECOVER)
@@ -60,12 +60,12 @@ public struct Libxml2XMLParserOptions: OptionSet {
     public typealias RawValue = UInt
     private var value: UInt = 0
     init(_ value: UInt) { self.value = value }
-    private init(_ opt: xmlParserOption) { self.value = UInt(opt.rawValue) }
+    private init(_ opt: xmlParserOption) { value = UInt(opt.rawValue) }
     public init(rawValue value: UInt) { self.value = value }
-    public init(nilLiteral: ()) { self.value = 0 }
-    public static var allZeros: Libxml2XMLParserOptions { return .init(0) }
-    static func fromMask(raw: UInt) -> Libxml2XMLParserOptions { return .init(raw) }
-    public var rawValue: UInt { return self.value }
+    public init(nilLiteral: ()) { value = 0 }
+    public static var allZeros: Libxml2XMLParserOptions { .init(0) }
+    static func fromMask(raw: UInt) -> Libxml2XMLParserOptions { .init(raw) }
+    public var rawValue: UInt { value }
     
     public static let STRICT     = Libxml2XMLParserOptions(0)
     public static let RECOVER    = Libxml2XMLParserOptions(XML_PARSE_RECOVER)

--- a/Tests/KannaTests/KannaCSSTests.swift
+++ b/Tests/KannaTests/KannaCSSTests.swift
@@ -112,7 +112,7 @@ class KannaCSSTests: XCTestCase {
 
 extension KannaCSSTests {
     static var allTests: [(String, (KannaCSSTests) -> () throws -> Void)] {
-        return [
+        [
             ("testCSStoXPath", testCSStoXPath),
         ]
     }

--- a/Tests/KannaTests/KannaHTMLModifyingTests.swift
+++ b/Tests/KannaTests/KannaHTMLModifyingTests.swift
@@ -57,7 +57,7 @@ class KannaHTMLModifyingTests: XCTestCase {
 
 extension KannaHTMLModifyingTests {
     static var allTests: [(String, (KannaHTMLModifyingTests) -> () throws -> Void)] {
-        return [
+        [
             ("testHTML_MovingNode", testHTML_MovingNode)
         ]
     }

--- a/Tests/KannaTests/KannaHTMLTests.swift
+++ b/Tests/KannaTests/KannaHTMLTests.swift
@@ -203,7 +203,7 @@ class KannaHTMLTests: XCTestCase {
 
 extension KannaHTMLTests {
     static var allTests: [(String, (KannaHTMLTests) -> () throws -> Void)] {
-        return [
+        [
             //("testHTML4", testHTML4),
             //("testInnerHTML", testInnerHTML),
             ("testNSURL", testNSURL),

--- a/Tests/KannaTests/KannaTutorialsTest.swift
+++ b/Tests/KannaTests/KannaTutorialsTest.swift
@@ -193,7 +193,7 @@ class KannaTutorialsTests: XCTestCase {
 
 extension KannaTutorialsTests {
     static var allTests: [(String, (KannaTutorialsTests) -> () throws -> Void)] {
-        return [
+        [
             ("testParsingFromString", testParsingFromString),
             //("testParsingFromFile", testParsingFromFile),
             ("testParsingFromInternets", testParsingFromInternets),

--- a/Tests/KannaTests/KannaXMLModifyingTests.swift
+++ b/Tests/KannaTests/KannaXMLModifyingTests.swift
@@ -57,7 +57,7 @@ class KannaXMLModifyingTests: XCTestCase {
 
 extension KannaXMLModifyingTests {
     static var allTests: [(String, (KannaXMLModifyingTests) -> () throws -> Void)] {
-        return [
+        [
             ("testXML_MovingNode", testXML_MovingNode),
         ]
     }

--- a/Tests/KannaTests/KannaXMLTests.swift
+++ b/Tests/KannaTests/KannaXMLTests.swift
@@ -87,7 +87,7 @@ class KannaXMLTests: XCTestCase {
 
 extension KannaXMLTests {
     static var allTests: [(String, (KannaXMLTests) -> () throws -> Void)] {
-        return [
+        [
             //("testXml", testXml),
             ("testXmlThrows", testXmlThrows),
         ]


### PR DESCRIPTION
 - Use implicit returns
 - Remove unnecessary explicit references to `self`
 - Remove unnecessary `internal` access modifiers
 - `fileprivate` -> `private`