### PR TITLE
Adapt Package.swift for Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,13 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
+// Starting with Xcode 12, we don't need to depend on our own libxml2 target
+#if swift(>=5.3) && !os(Linux)
+let dependencies: [Target.Dependency] = []
+#else
+let dependencies: [Target.Dependency] = ["libxml2"]
+#endif
+
 #if swift(>=5.2) && !os(Linux)
 let pkgConfig: String? = nil
 #else


### PR DESCRIPTION
Fixes #240.

With Xcode 12, when we import Kanna into a project using SPM and then use `swift package generate-xcodeproj`, it'll generate a broken project. Apparently, starting with Xcode 12, the system "knows" where to find libxml2 and doesn't need our help finding it.

I assume we want to keep the system target for older macOS/Xcode versions, and Linux obviously.