### PR TITLE
Changed entities from Dictionary to Tuple Array

### DIFF
--- a/Sources/Kanna/libxmlHTMLNode.swift
+++ b/Sources/Kanna/libxmlHTMLNode.swift
@@ -216,9 +216,9 @@ private func libxmlGetNodeContent(_ nodePtr: xmlNodePtr) -> String? {
 }
 
 let entities = [
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;"
+    ("&", "&amp;"),
+    ("<", "&lt;"),
+    (">", "&gt;")
 ]
 
 private func escape(_ str: String) -> String {


### PR DESCRIPTION
`Dictionary` is not guaranteed in order, so the `escape()` function often fails to replace strings.

Example

```swift
let str = "&<>"
let result = escape(str)
```

Expect: `&amp;&lt;&gt;`
Bad case1: `&amp;&amp;lt;&gt;`
Bad case2: `&amp;&amp;lt;&amp;gt;`