### PR TITLE
fix: exclude path in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,9 +43,9 @@ let package = Package(
             dependencies: dependencies,
             path: "Sources",
             exclude: [
-                "Sources/Info.plist",
-                "Sources/Kanna.h",
-                "Tests/KannaTests/Data"
+                "Kanna/Info.plist",
+                "Kanna/Kanna.h",
+                "../Tests/KannaTests/Data"
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Remove the `File not found` warning mentioned here https://github.com/tid-kijyun/Kanna/issues/248.