### PR TITLE
 Class is deprecated as a protocol's inheritance

### DIFF
--- a/Sources/Kanna/Kanna.swift
+++ b/Sources/Kanna/Kanna.swift
@@ -176,7 +176,7 @@ public protocol XMLElement: SearchableNode {
 /**
 XMLDocument
 */
-public protocol XMLDocument: class, SearchableNode {
+public protocol XMLDocument: AnyObject, SearchableNode {
     var namespaces: [Namespace] { get }
 }
 


### PR DESCRIPTION
I've gotten a caution, which says Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead.
All I did was replaced protocol's Class inheritance to AnyObject. 

You can also check [this](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md) out! It says 
> This proposal merges the concepts of class and AnyObject, which now have the same meaning: they represent an existential for classes. To get rid of the duplication, we suggest only keeping AnyObject around. To reduce source-breakage to a minimum, class could be redefined as typealias class = AnyObject and give a deprecation warning on class for the first version of Swift this proposal is implemented in. Later, class could be removed in a subsequent version of Swift.