### PR TITLE
Fix crash when access regexDict from multiple threads

### DIFF
--- a/Sources/Kanna/CSS.swift
+++ b/Sources/Kanna/CSS.swift
@@ -103,10 +103,15 @@ public enum CSS {
     }
 }
 
+private let lock = NSLock()
 private var regexDict: [String: AKRegularExpression] = [:]
 private func firstMatch(_ pattern: String) -> (String) -> AKTextCheckingResult? {
     return { str in
         let length = str.utf16.count
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
         if regexDict[pattern] == nil {
             regexDict[pattern] = try? AKRegularExpression(pattern: pattern, options: .caseInsensitive)
         }


### PR DESCRIPTION
Fix: #253

Add NSLock for thread safety.
