### PR TITLE
Update libxmlHTMLDocument.swift

### DIFF
--- a/Sources/Kanna/libxmlHTMLDocument.swift
+++ b/Sources/Kanna/libxmlHTMLDocument.swift
@@ -131,7 +131,7 @@ extension String.Encoding {
         guard let cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc) else {
             return nil
         }
-        return String(describing: cfencstr)
+        return cfencstr as String
         #endif
     }
 }


### PR DESCRIPTION
There's no need to describe a CFString: just cast it to a Swift String.