### PR TITLE
fix: Fallback of ascii encoding when encoding HTML.

### DIFF
--- a/Sources/Kanna/Kanna.swift
+++ b/Sources/Kanna/Kanna.swift
@@ -95,10 +95,13 @@ public func HTML(html: String, url: String? = nil, encoding: String.Encoding, op
 
 // NSData
 public func HTML(html: Data, url: String? = nil, encoding: String.Encoding, option: ParseOption = kDefaultHtmlParseOption) throws -> HTMLDocument {
-    guard let htmlStr = String(data: html, encoding: encoding) else {
+    if let htmlStr = String(data: html, encoding: encoding) {
+        return try HTML(html: htmlStr, url: url, encoding: encoding, option: option)
+    } else if let htmlStr = String(data: html, encoding: .ascii) {
+        return try HTML(html: htmlStr, url: url, encoding: encoding, option: option)
+    } else {
         throw ParseError.EncodingMismatch
     }
-    return try HTML(html: htmlStr, url: url, encoding: encoding, option: option)
 }
 
 // NSURL


### PR DESCRIPTION
Adding ascii encoding fallback for if .utf8 fails to produce an htmlStr.

This fix still does exactly the same thing as before except that now, before throwing an error, it tries to encode the htmlStr via .ascii before throwing an error.

This is concerning Issue: [257](https://github.com/tid-kijyun/Kanna/issues/257)