### PR TITLE
Fix force-unwrap crash in XPathObject subscript when result is not a NodeSet

### DIFF
--- a/Sources/Kanna/Kanna.swift
+++ b/Sources/Kanna/Kanna.swift
@@ -327,7 +327,7 @@ extension XPathObject {
     }
 
     public subscript(index: Int) -> XMLElement {
-        nodeSet![index]
+        nodeSetValue[index]
     }
 
     public var first: XMLElement? {


### PR DESCRIPTION
Replace `nodeSet!` with `nodeSetValue` to avoid an unclear nil force-unwrap crash. Ideally the return type should be Optional to handle this safely, but that would be a breaking API change. This approach produces a standard Array index out of range error instead, consistent with NodeSet subscript behavior.