### PR TITLE
Fix crash when accessing parent of an unlinked node

### DIFF
--- a/Sources/Kanna/libxmlHTMLNode.swift
+++ b/Sources/Kanna/libxmlHTMLNode.swift
@@ -98,7 +98,7 @@ final class libxmlHTMLNode: XMLElement {
 
     var parent: XMLElement? {
         get {
-            libxmlHTMLNode(document: doc, docPtr: docPtr, node: nodePtr.pointee.parent)
+            node(from: nodePtr.pointee.parent)
         }
         set {
             if let node = newValue as? libxmlHTMLNode {

--- a/Tests/KannaTests/KannaHTMLTests.swift
+++ b/Tests/KannaTests/KannaHTMLTests.swift
@@ -239,6 +239,20 @@ class KannaHTMLTests: XCTestCase {
             XCTFail("Abnormal test data")
         }
     }
+
+    func testHTML_UnlinkedNodeParent() {
+        guard let doc = try? HTML(html: "<body><div><p>hello</p></div></body>", encoding:
+    .utf8),
+              let div = doc.at_css("div"),
+              let p = doc.at_css("p") else {
+            XCTFail()
+            return
+        }
+
+        div.removeChild(p)
+
+        XCTAssertNil(p.parent)
+    }
 }
 
 extension KannaHTMLTests {


### PR DESCRIPTION
After removeChild, xmlUnlinkNode sets the node's parent to NULL. Accessing the parent property on such a node passed NULL to a non-optional parameter, causing a crash. Use the existing `node(from:)` helper which safely handles nil pointers.