### PR TITLE
Add children property to XMLElement for direct child element access

### DIFF
--- a/Sources/Kanna/Kanna.swift
+++ b/Sources/Kanna/Kanna.swift
@@ -168,6 +168,7 @@ XMLElement
 */
 public protocol XMLElement: SearchableNode {
     var parent: XMLElement? { get set }
+    var children: [XMLElement] { get }
     var attributes: [String: String] { get }
     subscript(attr: String) -> String? { get set }
 

--- a/Sources/Kanna/libxmlHTMLNode.swift
+++ b/Sources/Kanna/libxmlHTMLNode.swift
@@ -107,6 +107,18 @@ final class libxmlHTMLNode: XMLElement {
         }
     }
 
+    var children: [XMLElement] {
+        var result: [XMLElement] = []
+        var child = nodePtr.pointee.children
+        while let current = child {
+            if current.pointee.type == XML_ELEMENT_NODE {
+                result.append(libxmlHTMLNode(document: doc, docPtr: docPtr, node: current))
+            }
+            child = current.pointee.next
+        }
+        return result
+    }
+
     var nextSibling: XMLElement? {
         node(from: xmlNextElementSibling(nodePtr))
     }

--- a/Tests/KannaTests/KannaHTMLTests.swift
+++ b/Tests/KannaTests/KannaHTMLTests.swift
@@ -155,6 +155,47 @@ class KannaHTMLTests: XCTestCase {
         XCTAssert(previous.text == "first")
     }
 
+    func testChildren() {
+        let html = "<body><div><p>first</p><span>second</span><h1>third</h1></div></body>"
+
+        guard let doc = try? HTML(html: html, encoding: .utf8),
+              let div = doc.at_css("div") else {
+            XCTFail()
+            return
+        }
+
+        let children = div.children
+        XCTAssertEqual(children.count, 3)
+        XCTAssertEqual(children[0].tagName, "p")
+        XCTAssertEqual(children[1].tagName, "span")
+        XCTAssertEqual(children[2].tagName, "h1")
+    }
+
+    func testChildrenEmpty() {
+        let html = "<body><div></div></body>"
+
+        guard let doc = try? HTML(html: html, encoding: .utf8),
+              let div = doc.at_css("div") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(div.children.count, 0)
+    }
+
+    func testChildrenSkipsTextNodes() {
+        let html = "<body><div>text<p>child</p>more text</div></body>"
+
+        guard let doc = try? HTML(html: html, encoding: .utf8),
+              let div = doc.at_css("div") else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(div.children.count, 1)
+        XCTAssertEqual(div.children[0].tagName, "p")
+    }
+
     func testEmptyHTML() {
         XCTAssertThrowsError(try HTML(html: "", encoding: .utf8)) { error in
             XCTAssertEqual(error as? ParseError, ParseError.Empty)


### PR DESCRIPTION
## Added
- `children` property on `XMLElement` to get direct child elements

## Breaking Changes
- `XMLElement` protocol now requires a `children` property.
   If you have custom types conforming to `XMLElement`, you will need to
   add a `var children: [XMLElement] { get }` implementation.